### PR TITLE
docs: move rss support to Optional section

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This test doesn't contain the default theme. You have to install the theme you w
 
 ### `<head>`
 
-- Use the proper [DOCTYPE](https://en.wikipedia.org/wiki/Document_Type_Declaration).  
+- Use the proper [DOCTYPE](https://en.wikipedia.org/wiki/Document_Type_Declaration).
   If you don't know which doctype you should use, `<!DOCTYPE html>` is recommended.
 - UTF8 charset
 
@@ -29,12 +29,6 @@ This test doesn't contain the default theme. You have to install the theme you w
     ```
 
 - Proper titles for different pages
-- RSS support
-
-    ``` html
-    <link rel="alternate" href="path/of/rss" type="application/atom+xml">
-    ```
-
 - Favicon support
 
     ``` html
@@ -56,7 +50,7 @@ This test doesn't contain the default theme. You have to install the theme you w
 
 ### Performance
 
-- Use [fragment_cache](https://hexo.io/docs/helpers.html#fragment_cache)  
+- Use [fragment_cache](https://hexo.io/docs/helpers.html#fragment_cache)
   It caches render result across post/pages, see [#1769](https://github.com/hexojs/hexo/issues/1769) for the impact
 
 ### Optional
@@ -65,6 +59,21 @@ This test doesn't contain the default theme. You have to install the theme you w
 - i18n
 - Post share
 - SEO
+- RSS [Autodiscovery](http://www.rssboard.org/rss-autodiscovery) support
+  * Example:
+  ``` html
+  <link rel="alternate" href="path/of/rss" type="application/atom+xml">
+  ```
+  * Some RSS plugins (e.g. [hexo-generator-feed](https://github.com/hexojs/hexo-generator-feed) 2.1+) insert autodiscovery by default. There is a slight performance benefit if a theme inserts it, instead of the plugin. To take advantage of that, autodiscovery needs to be disabled in the plugin.
+    ``` yml
+    feed:
+      autodiscovery: false
+    ```
+  * RSS plugin could generate more than one type of RSS (e.g. Atom & RSS2). Here is an example EJS snippet for multi-format support by utilizing [`feed_tag`](https://hexo.io/docs/helpers#feed-tag) helper:
+    ``` js
+    <%- feed_tag() %>
+    ```
+  * If you decide to support autodiscovery, we recommend checking the updates of [hexo-generator-feed](https://github.com/hexojs/hexo-generator-feed/releases) (or any other RSS plugin that your theme prefers) from time to time. The configuration and functionality of an RSS plugin may change over time.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,17 @@ This test doesn't contain the default theme. You have to install the theme you w
     feed:
       autodiscovery: false
     ```
-  * RSS plugin could generate more than one type of RSS (e.g. Atom & RSS2). Here is an example EJS snippet for multi-format support by utilizing [`feed_tag`](https://hexo.io/docs/helpers#feed-tag) helper:
+  * hexo-generator-feed plugin could generate more than one type of RSS (e.g. Atom & RSS2). Here is an example EJS snippet for multi-format support by utilizing [`feed_tag`](https://hexo.io/docs/helpers#feed-tag) helper:
     ``` js
     <%- feed_tag() %>
+    ```
+    * If you want to support other plugins, in addition to hexo-generator-feed:
+    ``` js
+    <% if (config.feed) { %>
+      <%- feed_tag() %>
+    <% } else if (theme.rss) { %>
+      <%- feed_tag(theme.rss) %>
+    <% } %>
     ```
   * If you decide to support autodiscovery, we recommend checking the updates of [hexo-generator-feed](https://github.com/hexojs/hexo-generator-feed/releases) (or any other RSS plugin that your theme prefers) from time to time. The configuration and functionality of an RSS plugin may change over time.
 


### PR DESCRIPTION
While there is a performance advantage of inserting rss autodiscovery tag through a theme, however there could be compatibility issue as the configuration and functionality of an rss plugin may change from time to time.

Example issue is https://github.com/hexojs/hexo-generator-feed/issues/112 which necessitate a workaround https://github.com/hexojs/hexo-generator-feed/pull/114.

hexo-generator-feed [2.1+](https://github.com/hexojs/hexo-generator-feed/releases/tag/2.1.0) now inserts autodiscovery, thus it is not mandatory for the theme to do so anymore. If a theme decides to support it, it is the theme's responsibility to check compatibility with newer versions of an RSS plugin and utilize relevant workaround (in the theme).