### PR TITLE
Add `hexo-tag-embed`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "hexo-generator-index": "^3.0.0",
     "hexo-generator-tag": "^2.0.0",
     "hexo-renderer-ejs": "^2.0.0",
-    "hexo-renderer-stylus": "^2.0.0",
     "hexo-renderer-marked": "^6.0.0",
-    "hexo-server": "^3.0.0"
+    "hexo-renderer-stylus": "^2.0.0",
+    "hexo-server": "^3.0.0",
+    "hexo-tag-embed": "latest"
   }
 }


### PR DESCRIPTION
Missing `hexo-tag-embed` is causing `hexojs/hexo` benchmark to fail.