### PR TITLE
fix: update small picture URL in images test

### DIFF
--- a/source/_posts/images.md
+++ b/source/_posts/images.md
@@ -10,4 +10,4 @@ This is a image test post.
 
 ![](/assets/wallpaper-878514.jpg)
 
-![Small Picture](https://via.placeholder.com/350x150.jpg)
+![Small Picture](https://placehold.co/350x150.jpg)


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo!
-->

## check list

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.

## Description

The link `https://via.placeholder.com` is broken. Update it to use `https://placehold.co/` instead.
